### PR TITLE
Add --update-existing option to add_institution command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme:
 
 setuptools.setup(
     name="django-uniauth",
-    version="1.2.0",
+    version="1.2.1",
     author="Lance Goodridge",
     author_email="ldgoodridge95@gmail.com",
     keywords=["django", "auth", "authentication", "cas", "sso", "single sign-on"],

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -31,12 +31,33 @@ class AddInstitutionCommandTests(TestCase):
         """
         call_command("add_institution", "Test", "https://www.example.com")
         call_command("add_institution", "Other Inst", "http://fed.foobar.edu/")
+        call_command("add_institution", "Test", "https://www.example.com",
+            "--update-existing")
         actual = Institution.objects.order_by("slug")
         expected = [
                 Institution(name="Other Inst", slug="other-inst",
                     cas_server_url="http://fed.foobar.edu/"),
                 Institution(name="Test", slug="test",
                     cas_server_url="https://www.example.com"),
+        ]
+        self._check_institutions(actual, expected)
+
+    def test_add_institution_command_update_existing_valid_inputs(self):
+        """
+        Ensures command works as expected for valid inputs with the
+        --update-existing option.
+        """
+        call_command("add_institution", "Test", "https://www.example.com",
+            "--update-existing")
+        call_command("add_institution", "Other Inst", "http://fed.foobar.edu/")
+        call_command("add_institution", "Test", "https://fed.university.edu/",
+             "--update-existing")
+        actual = Institution.objects.order_by("slug")
+        expected = [
+                Institution(name="Other Inst", slug="other-inst",
+                    cas_server_url="http://fed.foobar.edu/"),
+                Institution(name="Test", slug="test",
+                    cas_server_url="https://fed.university.edu/"),
         ]
         self._check_institutions(actual, expected)
 
@@ -55,7 +76,6 @@ class AddInstitutionCommandTests(TestCase):
         call_command("add_institution", "Test", "https://www.example.com")
         self.assertRaisesRegex(CommandError, "exists", call_command,
                 "add_institution", "test", "https://www.foo.bar")
-
 
 class MigrateCASCommandTests(TestCase):
     """

--- a/uniauth/management/commands/add_institution.py
+++ b/uniauth/management/commands/add_institution.py
@@ -16,14 +16,20 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('name')
         parser.add_argument('cas_server_url')
+        parser.add_argument(
+            '--update-existing',
+            action='store_true',
+            default=False,
+            help='Update the institution, if it already exists.')
 
     def handle(self, *args, **options):
         slug = slugify(options['name'])
         cas_server_url = options['cas_server_url']
 
-        if Institution.objects.filter(slug=slug).exists():
+        if (not options['update_existing']
+            and Institution.objects.filter(slug=slug).exists()):
             raise CommandError("An institution with slug '" +
-                    slug + "' already exists.")
+                        slug + "' already exists.")
 
         try:
             validator = URLValidator()
@@ -31,7 +37,18 @@ class Command(BaseCommand):
         except ValidationError:
             raise CommandError("Provided CAS server URL '" +
                     cas_server_url + "' is malformed.")
+      
+        institution, created = Institution.objects.get_or_create(
+            name=options['name'],
+            slug=slug,
+            defaults={'cas_server_url': cas_server_url}
+            )
 
-        institution = Institution.objects.create(name=options['name'],
-                slug=slug, cas_server_url=cas_server_url)
-        self.stdout.write("Created institution '%s'.\n" % str(institution))
+        if created:
+            self.stdout.write("Created institution '%s'.\n" % str(institution))
+        elif institution.cas_server_url != cas_server_url:
+            # If institution already exists but with a different URL,
+            # update it.
+            institution.cas_server_url = cas_server_url
+            institution.save()
+            self.stdout.write("Updated institution '%s'.\n" % str(institution))


### PR DESCRIPTION
This allows two very useful features:

1. Updating the CAS server URL without removing the institution first; removing the institution has the side effect of cascading deletes.
2. No-ops. In a deployment, it is common to have these sort of "bootstrapping" operations (another example is the "migrate" command) run automatically on-deploy. For such a use case, having an option for the command to be a no-op if the institution already exists is very beneficial.