### PR TITLE
Use transactions in migrate_cas and migrate_custom management commands

### DIFF
--- a/uniauth/management/commands/migrate_cas.py
+++ b/uniauth/management/commands/migrate_cas.py
@@ -5,6 +5,7 @@ CAS for authentication over to Uniauth.
 Execution: python manage.py migrate_cas <slug>
 """
 
+from django.db import transaction
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from uniauth.models import Institution, InstitutionAccount, UserProfile
@@ -16,6 +17,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('slug')
 
+    @transaction.atomic
     def handle(self, *args, **options):
         slug = options['slug']
 

--- a/uniauth/management/commands/migrate_custom.py
+++ b/uniauth/management/commands/migrate_custom.py
@@ -5,6 +5,7 @@ custom User authentication over to Uniauth.
 Execution: python manage.py migrate_custom
 """
 
+from django.db import transaction
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from uniauth.models import LinkedEmail, UserProfile
@@ -13,6 +14,7 @@ from uniauth.utils import get_input
 class Command(BaseCommand):
     help = "Migrates a project using custom User auhentication to Uniauth."
 
+    @transaction.atomic
     def handle(self, *args, **options):
         message = ("This command is intended to migrate projects "
             "previously using custom User authentication to using Uniauth.\n\n"


### PR DESCRIPTION
This is beneficial for two primary reasons:

1. Atomic migrations. A failure for a single user will not leave the
   database in an intermediate state where some users are migrated
   and others are not.
2. Faster run time. Wrapping a large number of writes in a transaction
   usually results in faster completion.