### PR TITLE
Changed 'Select Server' -> 'Select Institution'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme:
 
 setuptools.setup(
     name="django-uniauth",
-    version="1.2.1",
+    version="1.2.2",
     author="Lance Goodridge",
     author_email="ldgoodridge95@gmail.com",
     keywords=["django", "auth", "authentication", "cas", "sso", "single sign-on"],

--- a/uniauth/templates/uniauth/login.html
+++ b/uniauth/templates/uniauth/login.html
@@ -76,7 +76,7 @@
                                         <a id="cas-link" href="{{ institutions.0.2 }}{{ query_params }}">To {{ institutions.0.0 }} CAS</a>
                                     {% else %}
                                         <select id="cas-select" class="form-control input-block {% if not display_standard %}only-cas-login{% endif %}" onchange="tmp=this.value;this.value='';location=tmp;">
-                                            <option value="" selected="selected" disabled="disabled" hidden="hidden">(Select Server)</option>
+                                            <option value="" selected="selected" disabled="disabled" hidden="hidden">(Select Institution)</option>
                                             {% for institution in institutions %}
                                             <option value="{{ institution.2 }}{{ query_params }}">{{ institution.0 }}</option>
                                             {% endfor %}


### PR DESCRIPTION
The "Select Server" caption is reportedly confusing to students. A more neutral and understandable caption would be "Select Institution"—as "Institution" is a notion that non-tech users can understand more readily than "Server."